### PR TITLE
[codex] Harden Remeha Home integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # artifacts
 __pycache__
 .pytest*
+.venv/
 *.egg-info
 */build/*
 */dist/*

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -2,6 +2,7 @@
 
 target-version = "py310"
 
+[lint]
 select = [
     "B007", # Loop control variable {name} not used within loop body
     "B014", # Exception handler with duplicate exception
@@ -38,11 +39,11 @@ ignore = [
     "E731",  # do not assign a lambda expression, use a def
 ]
 
-[flake8-pytest-style]
+[lint.flake8-pytest-style]
 fixture-parentheses = false
 
-[pyupgrade]
+[lint.pyupgrade]
 keep-runtime-typing = true
 
-[mccabe]
+[lint.mccabe]
 max-complexity = 25

--- a/custom_components/remeha_home/api.py
+++ b/custom_components/remeha_home/api.py
@@ -8,6 +8,7 @@ import json
 import logging
 import secrets
 import urllib
+from json import JSONDecodeError
 
 from aiohttp import ClientSession
 
@@ -314,7 +315,13 @@ class RemehaHomeOAuth2Implementation(AbstractOAuth2Implementation):
                 },
             )
             response.raise_for_status()
-            response_json = json.loads(await response.text())
+            try:
+                response_json = json.loads(await response.text())
+            except JSONDecodeError as err:
+                _LOGGER.warning(
+                    "Remeha Home authentication returned an unexpected non-JSON response"
+                )
+                raise RemehaHomeAuthFailed from err
             if response_json["status"] != "200":
                 raise RemehaHomeAuthFailed
 
@@ -370,14 +377,14 @@ class RemehaHomeOAuth2Implementation(AbstractOAuth2Implementation):
             #       problem has not been found, but this workaround allows you to reauthenticate at least. Otherwise
             #       Home Assistant would get stuck on refreshing the token forever.
             if response.status == 400:
-                response_json = await response.json()
+                response_json = await response.json(content_type=None)
                 _LOGGER.error(
                     "OAuth2 token request returned '400 Bad Request': %s",
-                    response_json["error_description"],
+                    response_json.get("error_description", response_json),
                 )
                 raise ConfigEntryAuthFailed
 
             response.raise_for_status()
-            response_json = await response.json()
+            response_json = await response.json(content_type=None)
 
         return response_json

--- a/custom_components/remeha_home/binary_sensor.py
+++ b/custom_components/remeha_home/binary_sensor.py
@@ -90,6 +90,11 @@ class RemehaHomeBinarySensor(CoordinatorEntity, BinarySensorEntity):
         return self.coordinator.get_by_id(self.item_id)
 
     @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self._data is not None
+
+    @property
     def is_on(self) -> bool | None:
         """Return the state of this binary sensor."""
         data = self._data

--- a/custom_components/remeha_home/climate.py
+++ b/custom_components/remeha_home/climate.py
@@ -105,6 +105,15 @@ class RemehaHomeClimateEntity(CoordinatorEntity, ClimateEntity):
         return self.coordinator.get_by_id(self.climate_zone_id)
 
     @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return (
+            super().available
+            and self._data is not None
+            and self.coordinator.get_by_id(self.appliance_id) is not None
+        )
+
+    @property
     def device_info(self) -> DeviceInfo:
         """Return device info for this device."""
         return self.coordinator.get_device_info(self.climate_zone_id)
@@ -112,24 +121,30 @@ class RemehaHomeClimateEntity(CoordinatorEntity, ClimateEntity):
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
-        return self._data["roomTemperature"]
+        if self._data is None:
+            return None
+        return self._data.get("roomTemperature")
 
     @property
     def target_temperature(self) -> float | None:
         """Return the target temperature."""
-        if self.hvac_mode == HVACMode.OFF:
+        if self._data is None or self.hvac_mode == HVACMode.OFF:
             return None
-        return self._data["setPoint"]
+        return self._data.get("setPoint")
 
     @property
-    def min_temp(self) -> float:
+    def min_temp(self) -> float | None:
         """Return the minimum temperature."""
-        return self._data["setPointMin"]
+        if self._data is None:
+            return None
+        return self._data.get("setPointMin")
 
     @property
-    def max_temp(self) -> float:
+    def max_temp(self) -> float | None:
         """Return the maximum temperature."""
-        return self._data["setPointMax"]
+        if self._data is None:
+            return None
+        return self._data.get("setPointMax")
 
     @property
     def hvac_mode(self) -> HVACMode | str | None:
@@ -139,6 +154,8 @@ class RemehaHomeClimateEntity(CoordinatorEntity, ClimateEntity):
             return self._requested_hvac_mode
 
         zone_data = self._data
+        if zone_data is None:
+            return HVACMode.OFF
 
         # The true mode of the zone is reported in 'zoneMode'.
         # If it's 'FrostProtection', the zone is OFF regardless of appliance operatingMode.
@@ -147,6 +164,8 @@ class RemehaHomeClimateEntity(CoordinatorEntity, ClimateEntity):
 
         # If the zone is active, determine HEAT or COOL from the appliance's operatingMode.
         appliance_data = self.coordinator.get_by_id(self.appliance_id)
+        if appliance_data is None:
+            return HVACMode.OFF
         operating_mode = appliance_data.get("operatingMode")
 
         if operating_mode is None:
@@ -162,6 +181,8 @@ class RemehaHomeClimateEntity(CoordinatorEntity, ClimateEntity):
     @property
     def hvac_action(self) -> HVACAction | str | None:
         """Return HVAC action based on the activeComfortDemand field from the API."""
+        if self._data is None:
+            return None
         active_comfort = self._data.get("activeComfortDemand")
         if active_comfort in REMEHA_STATUS_TO_HVAC_ACTION:
             return REMEHA_STATUS_TO_HVAC_ACTION[active_comfort]
@@ -181,6 +202,8 @@ class RemehaHomeClimateEntity(CoordinatorEntity, ClimateEntity):
         'manual' when the zone is in manual mode.
         'schedule1/2/3' when in schedule mode, based on the active program number.
         """
+        if self._data is None:
+            return None
         zone_mode = self._data.get("zoneMode")
         if self.hvac_mode == HVACMode.OFF:
             return None
@@ -238,6 +261,9 @@ class RemehaHomeClimateEntity(CoordinatorEntity, ClimateEntity):
             return
 
         if preset_mode == "manual":
+            if self.target_temperature is None:
+                _LOGGER.error("Cannot set manual preset without a target temperature")
+                return
             await self.api.async_set_manual(self.climate_zone_id, self.target_temperature)
         else:
             heating_program = int(preset_mode[-1])
@@ -254,6 +280,9 @@ class RemehaHomeClimateEntity(CoordinatorEntity, ClimateEntity):
         if self._requested_hvac_mode is not None:
             zone_data = self._data
             appliance_data = self.coordinator.get_by_id(self.appliance_id)
+            if zone_data is None:
+                super()._handle_coordinator_update()
+                return
 
             # Check OFF state via zoneMode on the zone
             if zone_data.get("zoneMode") == "FrostProtection":

--- a/custom_components/remeha_home/const.py
+++ b/custom_components/remeha_home/const.py
@@ -16,6 +16,15 @@ DOMAIN = "remeha_home"
 # Shared API subscription key (public key embedded in the official app)
 API_SUBSCRIPTION_KEY = "df605c5470d846fc91e848b1cc653ddf"
 
+DEFAULT_CONSUMPTION_DATA = {
+    "heatingEnergyConsumed": None,
+    "hotWaterEnergyConsumed": None,
+    "coolingEnergyConsumed": None,
+    "heatingEnergyDelivered": None,
+    "hotWaterEnergyDelivered": None,
+    "coolingEnergyDelivered": None,
+}
+
 APPLIANCE_SENSOR_TYPES = [
     SensorEntityDescription(
         key="waterPressure",
@@ -45,9 +54,7 @@ APPLIANCE_SENSOR_TYPES = [
         entity_registry_enabled_default=False,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
-        # Daily values reset at midnight — MEASUREMENT is correct here.
-        # TOTAL_INCREASING would break the energy dashboard on reset.
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=SensorStateClass.TOTAL,
     ),
     SensorEntityDescription(
         key="consumptionData.hotWaterEnergyConsumed",
@@ -55,7 +62,7 @@ APPLIANCE_SENSOR_TYPES = [
         entity_registry_enabled_default=False,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=SensorStateClass.TOTAL,
     ),
     SensorEntityDescription(
         key="consumptionData.coolingEnergyConsumed",
@@ -63,7 +70,7 @@ APPLIANCE_SENSOR_TYPES = [
         entity_registry_enabled_default=False,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=SensorStateClass.TOTAL,
     ),
     SensorEntityDescription(
         key="consumptionData.heatingEnergyDelivered",
@@ -71,7 +78,7 @@ APPLIANCE_SENSOR_TYPES = [
         entity_registry_enabled_default=False,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=SensorStateClass.TOTAL,
     ),
     SensorEntityDescription(
         key="consumptionData.hotWaterEnergyDelivered",
@@ -79,7 +86,7 @@ APPLIANCE_SENSOR_TYPES = [
         entity_registry_enabled_default=False,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=SensorStateClass.TOTAL,
     ),
     SensorEntityDescription(
         key="consumptionData.coolingEnergyDelivered",
@@ -87,7 +94,7 @@ APPLIANCE_SENSOR_TYPES = [
         entity_registry_enabled_default=False,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=SensorStateClass.TOTAL,
     ),
     SensorEntityDescription(
         key="errorStatus",

--- a/custom_components/remeha_home/coordinator.py
+++ b/custom_components/remeha_home/coordinator.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from datetime import timedelta
 
-from aiohttp.client_exceptions import ClientResponseError
+from aiohttp.client_exceptions import ClientError, ClientResponseError
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -13,7 +13,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 import homeassistant.util.dt as dt_util
 
 from .api import RemehaHomeAPI
-from .const import DOMAIN
+from .const import DEFAULT_CONSUMPTION_DATA, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,35 +36,14 @@ class RemehaHomeUpdateCoordinator(DataUpdateCoordinator):
         self.appliance_consumption_data = {}
         self.appliance_last_consumption_data_update = {}
 
-    async def _async_update_data(self):
-        """Fetch data from API endpoint.
+    async def _async_get_technical_info(self, appliance: dict) -> dict:
+        """Return cached technical info, falling back to safe defaults."""
+        appliance_id = appliance["applianceId"]
+        if appliance_id in self.technical_info:
+            return self.technical_info[appliance_id]
 
-        This is the place to pre-process the data to lookup tables
-        so entities can quickly look up their data.
-        """
         try:
-            # Note: asyncio.TimeoutError and aiohttp.ClientError are already
-            # handled by the data update coordinator.
-            async with asyncio.timeout(30):
-                data = await self.api.async_get_dashboard()
-                _LOGGER.debug("Requested dashboard information: %s", data)
-        except ClientResponseError as err:
-            # Raising ConfigEntryAuthFailed will cancel future updates
-            # and start a config flow with SOURCE_REAUTH (async_step_reauth)
-            if err.status == 401:
-                raise ConfigEntryAuthFailed from err
-
-            raise UpdateFailed from err
-
-        # Save the current time (timezone-aware) for appliance usage data updates
-        now = dt_util.now()
-
-        for appliance in data["appliances"]:
-            appliance_id = appliance["applianceId"]
-            self.items[appliance_id] = appliance
-
-            # Request appliance technical information the first time it is discovered
-            if appliance_id not in self.technical_info:
+            async with asyncio.timeout(15):
                 self.technical_info[appliance_id] = (
                     await self.api.async_get_appliance_technical_information(
                         appliance_id
@@ -75,77 +54,132 @@ class RemehaHomeUpdateCoordinator(DataUpdateCoordinator):
                     appliance_id,
                     self.technical_info[appliance_id],
                 )
+        except ClientResponseError as err:
+            if err.status == 401:
+                raise ConfigEntryAuthFailed from err
+            _LOGGER.warning(
+                "Failed to request technical information for appliance %s: %s",
+                appliance_id,
+                err,
+            )
+            self.technical_info[appliance_id] = self._default_technical_info(appliance)
+        except (TimeoutError, ClientError) as err:
+            _LOGGER.warning(
+                "Failed to request technical information for appliance %s: %s",
+                appliance_id,
+                err,
+            )
+            self.technical_info[appliance_id] = self._default_technical_info(appliance)
 
-            # Only update appliance usage data every 15 minutes
-            if (appliance_id not in self.appliance_last_consumption_data_update) or (
-                now - self.appliance_last_consumption_data_update[appliance_id]
-                >= timedelta(minutes=14, seconds=45)
-            ):
-                try:
-                    consumption_data = (
-                        await self.api.async_get_consumption_data_for_today(
-                            appliance_id
-                        )
-                    )
-                    _LOGGER.debug(
-                        "Requested consumption data for appliance %s: %s",
-                        appliance_id,
-                        consumption_data,
-                    )
+        return self.technical_info[appliance_id]
 
-                    if len(consumption_data["data"]) > 0:
-                        self.appliance_consumption_data[appliance_id] = (
-                            consumption_data["data"][0]
-                        )
-                    else:
-                        _LOGGER.warning(
-                            "No consumption data found for appliance %s", appliance_id
-                        )
-                        self.appliance_consumption_data[appliance_id] = {
-                            "heatingEnergyConsumed": 0.0,
-                            "hotWaterEnergyConsumed": 0.0,
-                            "coolingEnergyConsumed": 0.0,
-                            "heatingEnergyDelivered": 0.0,
-                            "hotWaterEnergyDelivered": 0.0,
-                            "coolingEnergyDelivered": 0.0,
-                        }
+    async def _async_update_consumption_data(
+        self, appliance_id: str, now
+    ) -> dict | None:
+        """Refresh appliance consumption data when due."""
+        if appliance_id in self.appliance_last_consumption_data_update and (
+            now - self.appliance_last_consumption_data_update[appliance_id]
+            < timedelta(minutes=14, seconds=45)
+        ):
+            return self.appliance_consumption_data.get(appliance_id)
 
-                    self.appliance_last_consumption_data_update[appliance_id] = now
-                except ClientResponseError as err:
-                    _LOGGER.warning(
-                        "Failed to request consumption data for appliance %s: %s",
-                        appliance_id,
-                        err,
-                    )
-
-            # Get the cached consumption data for the appliance or use default values
-            if appliance_id in self.appliance_consumption_data:
-                appliance["consumptionData"] = self.appliance_consumption_data[
-                    appliance_id
-                ]
+        try:
+            async with asyncio.timeout(20):
+                consumption_data = (
+                    await self.api.async_get_consumption_data_for_today(appliance_id)
+                )
+            _LOGGER.debug(
+                "Requested consumption data for appliance %s: %s",
+                appliance_id,
+                consumption_data,
+            )
+            data = consumption_data.get("data") or []
+            if data:
+                self.appliance_consumption_data[appliance_id] = data[0]
             else:
-                appliance["consumptionData"] = {
-                    "heatingEnergyConsumed": 0.0,
-                    "hotWaterEnergyConsumed": 0.0,
-                    "coolingEnergyConsumed": 0.0,
-                    "heatingEnergyDelivered": 0.0,
-                    "hotWaterEnergyDelivered": 0.0,
-                    "coolingEnergyDelivered": 0.0,
-                }
+                _LOGGER.debug(
+                    "No consumption data found for appliance %s", appliance_id
+                )
+                self.appliance_consumption_data.pop(appliance_id, None)
 
-            self.device_info[appliance_id] = DeviceInfo(
-                identifiers={(DOMAIN, appliance_id)},
-                name=appliance["houseName"],
-                manufacturer="Remeha",
-                model=self.technical_info[appliance_id]["applianceName"],
+            self.appliance_last_consumption_data_update[appliance_id] = now
+        except ClientResponseError as err:
+            if err.status == 401:
+                raise ConfigEntryAuthFailed from err
+            _LOGGER.warning(
+                "Failed to request consumption data for appliance %s: %s",
+                appliance_id,
+                err,
+            )
+        except (TimeoutError, ClientError) as err:
+            _LOGGER.warning(
+                "Failed to request consumption data for appliance %s: %s",
+                appliance_id,
+                err,
             )
 
-            for climate_zone in appliance["climateZones"]:
+        return self.appliance_consumption_data.get(appliance_id)
+
+    @staticmethod
+    def _default_technical_info(appliance: dict) -> dict:
+        """Return safe technical info when the optional endpoint is unavailable."""
+        return {
+            "applianceName": appliance.get("applianceName") or "Unknown",
+            "internetConnectedGateways": [],
+        }
+
+    async def _async_update_data(self):
+        """Fetch data from API endpoint.
+
+        This is the place to pre-process the data to lookup tables
+        so entities can quickly look up their data.
+        """
+        try:
+            async with asyncio.timeout(45):
+                data = await self.api.async_get_dashboard()
+                _LOGGER.debug("Requested dashboard information: %s", data)
+        except ClientResponseError as err:
+            # Raising ConfigEntryAuthFailed will cancel future updates
+            # and start a config flow with SOURCE_REAUTH (async_step_reauth)
+            if err.status == 401:
+                raise ConfigEntryAuthFailed from err
+
+            raise UpdateFailed from err
+        except (TimeoutError, ClientError) as err:
+            raise UpdateFailed from err
+
+        # Save the current time (timezone-aware) for appliance usage data updates
+        now = dt_util.now()
+        items = {}
+        device_info = {}
+
+        for appliance in data.get("appliances", []):
+            appliance_id = appliance["applianceId"]
+            items[appliance_id] = appliance
+
+            technical_info = await self._async_get_technical_info(appliance)
+            consumption_data = await self._async_update_consumption_data(
+                appliance_id, now
+            )
+
+            # Get the cached consumption data for the appliance or use default values
+            appliance["consumptionData"] = (
+                consumption_data.copy()
+                if consumption_data
+                else DEFAULT_CONSUMPTION_DATA.copy()
+            )
+
+            device_info[appliance_id] = DeviceInfo(
+                identifiers={(DOMAIN, appliance_id)},
+                name=(appliance.get("houseName") or "Remeha Home").strip(),
+                manufacturer="Remeha",
+                model=technical_info.get("applianceName", "Unknown"),
+            )
+
+            for climate_zone in appliance.get("climateZones", []):
                 climate_zone_id = climate_zone["climateZoneId"]
                 # This assumes that all climate zones for an appliance share the same gateway
-                gateways = self.technical_info[appliance_id][
-                    "internetConnectedGateways"
-                ]
+                gateways = technical_info.get("internetConnectedGateways", [])
 
                 if len(gateways) > 1:
                     _LOGGER.warning(
@@ -166,10 +200,10 @@ class RemehaHomeUpdateCoordinator(DataUpdateCoordinator):
                         "softwareVersion": "Unknown",
                     }
 
-                self.items[climate_zone_id] = climate_zone
-                self.device_info[climate_zone_id] = DeviceInfo(
+                items[climate_zone_id] = climate_zone
+                device_info[climate_zone_id] = DeviceInfo(
                     identifiers={(DOMAIN, climate_zone_id)},
-                    name=climate_zone["name"],
+                    name=(climate_zone.get("name") or "Climate Zone").strip(),
                     manufacturer="Remeha",
                     model=gateway_info["name"],
                     hw_version=gateway_info["hardwareVersion"],
@@ -177,17 +211,19 @@ class RemehaHomeUpdateCoordinator(DataUpdateCoordinator):
                     via_device=(DOMAIN, appliance_id),
                 )
 
-            for hot_water_zone in appliance["hotWaterZones"]:
+            for hot_water_zone in appliance.get("hotWaterZones", []):
                 hot_water_zone_id = hot_water_zone["hotWaterZoneId"]
-                self.items[hot_water_zone_id] = hot_water_zone
-                self.device_info[hot_water_zone_id] = DeviceInfo(
+                items[hot_water_zone_id] = hot_water_zone
+                device_info[hot_water_zone_id] = DeviceInfo(
                     identifiers={(DOMAIN, hot_water_zone_id)},
-                    name=hot_water_zone["name"],
+                    name=(hot_water_zone.get("name") or "Hot Water Zone").strip(),
                     manufacturer="Remeha",
                     model="Hot Water Zone",
                     via_device=(DOMAIN, appliance_id),
                 )
 
+        self.items = items
+        self.device_info = device_info
         return data
 
     def get_by_id(self, item_id: str):

--- a/custom_components/remeha_home/manifest.json
+++ b/custom_components/remeha_home/manifest.json
@@ -9,5 +9,6 @@
   "integration_type": "device",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/petarlaf/remeha_home_baxi_hvac/issues",
+  "single_config_entry": true,
   "version": "1.0.0"
 }

--- a/custom_components/remeha_home/sensor.py
+++ b/custom_components/remeha_home/sensor.py
@@ -25,6 +25,8 @@ from .coordinator import RemehaHomeUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
+SENTINEL_TIMESTAMP_YEARS = {1}
+
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -80,6 +82,11 @@ class RemehaHomeSensor(CoordinatorEntity, SensorEntity):
         return self.coordinator.get_by_id(self.item_id)
 
     @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self._data is not None
+
+    @property
     def native_value(self):
         """Return the measurement value for this sensor."""
         data = self._data
@@ -104,6 +111,8 @@ class RemehaHomeSensor(CoordinatorEntity, SensorEntity):
                     value,
                     self.entity_description.key,
                 )
+                return None
+            if parsed.year in SENTINEL_TIMESTAMP_YEARS:
                 return None
             # Only add timezone if the parsed datetime is naive
             if parsed.tzinfo is None:

--- a/custom_components/remeha_home/switch.py
+++ b/custom_components/remeha_home/switch.py
@@ -69,9 +69,17 @@ class RemehaHomeSwitch(CoordinatorEntity, SwitchEntity):
         return self.coordinator.get_by_id(self.climate_zone_id)
 
     @property
-    def is_on(self) -> bool:
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self._data is not None
+
+    @property
+    def is_on(self) -> bool | None:
         """Return the state of this switch."""
-        return self._data[self.entity_description.key]
+        data = self._data
+        if data is None:
+            return None
+        return data.get(self.entity_description.key)
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/remeha_home/water_heater.py
+++ b/custom_components/remeha_home/water_heater.py
@@ -8,6 +8,7 @@ Based on the data provided by the dashboard API, the relevant fields are:
 """
 
 from __future__ import annotations
+from datetime import UTC, datetime
 import logging
 from typing import Any
 
@@ -28,6 +29,8 @@ from .coordinator import RemehaHomeUpdateCoordinator
 from .api import RemehaHomeAPI
 
 _LOGGER = logging.getLogger(__name__)
+
+SENTINEL_TIMESTAMP_YEARS = {1}
 
 
 async def async_setup_entry(
@@ -87,6 +90,11 @@ class RemehaHomeWaterHeater(CoordinatorEntity, WaterHeaterEntity):
         return self.coordinator.get_by_id(self.hot_water_zone_id)
 
     @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self._data is not None
+
+    @property
     def device_info(self) -> DeviceInfo:
         """Return device information for the water heater."""
         return self.coordinator.get_device_info(self.hot_water_zone_id)
@@ -94,6 +102,8 @@ class RemehaHomeWaterHeater(CoordinatorEntity, WaterHeaterEntity):
     @property
     def current_temperature(self) -> float | None:
         """Return the current water temperature."""
+        if self._data is None:
+            return None
         return self._data.get("dhwTemperature")
 
     @property
@@ -105,6 +115,8 @@ class RemehaHomeWaterHeater(CoordinatorEntity, WaterHeaterEntity):
         - Comfort: use "comfortSetPoint"
         """
         current_mode = self.current_operation
+        if self._data is None:
+            return None
         if current_mode == "Scheduled":
             return self._data.get("targetSetpoint")
         elif current_mode == "Eco":
@@ -117,6 +129,8 @@ class RemehaHomeWaterHeater(CoordinatorEntity, WaterHeaterEntity):
     def min_temp(self) -> float | None:
         """Return the minimum temperature allowed for the water heater."""
         current_mode = self.current_operation
+        if self._data is None:
+            return None
         set_point_ranges = self._data.get("setPointRanges", {})
         if current_mode == "Eco":
             return set_point_ranges.get("reducedSetpointMin", self._data.get("setPointMin"))
@@ -128,6 +142,8 @@ class RemehaHomeWaterHeater(CoordinatorEntity, WaterHeaterEntity):
     def max_temp(self) -> float | None:
         """Return the maximum temperature allowed for the water heater."""
         current_mode = self.current_operation
+        if self._data is None:
+            return None
         set_point_ranges = self._data.get("setPointRanges", {})
         if current_mode == "Eco":
             return set_point_ranges.get("reducedSetpointMax", self._data.get("setPointMax"))
@@ -138,6 +154,8 @@ class RemehaHomeWaterHeater(CoordinatorEntity, WaterHeaterEntity):
     @property
     def current_operation(self) -> str:
         """Return the current operation mode (Scheduled, Comfort, Eco, or Boost)."""
+        if self._data is None:
+            return "Unknown"
         raw_mode = self._data.get("dhwZoneMode", "Unknown")
         mode_mapping = {
             "continuouscomfort": "Comfort",
@@ -158,8 +176,10 @@ class RemehaHomeWaterHeater(CoordinatorEntity, WaterHeaterEntity):
             if boost_end_time:
                 try:
                     end_time = dt_util.parse_datetime(boost_end_time)
-                    if end_time is not None:
-                        now = dt_util.utcnow()
+                    if end_time is not None and end_time.year not in SENTINEL_TIMESTAMP_YEARS:
+                        if end_time.tzinfo is None:
+                            end_time = end_time.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
+                        now = datetime.now(UTC)
                         remaining_seconds = (end_time - now).total_seconds()
                         if remaining_seconds > 0:
                             remaining_minutes = int(remaining_seconds / 60)


### PR DESCRIPTION
## Summary

- Hardens coordinator refreshes so optional technical/consumption API failures do not break the whole update path.
- Fixes Home Assistant energy sensor state-class warnings by using valid energy state classes.
- Treats inactive/sentinel boost timestamps as missing values instead of real year-0001 timestamps.
- Adds explicit entity availability checks and trims API-provided device/zone names.
- Adds `single_config_entry`, modernizes Ruff config, and ignores the local `.venv/`.

## Validation

- `.venv\\Scripts\\python.exe -m ruff check .`
- `.venv\\Scripts\\python.exe -m compileall custom_components`
- `git diff --check`
- Read-only production Home Assistant baseline check against HA 2026.5.1 / installed Remeha Home v1.1.7, confirming the existing timeout, empty consumption-data, and energy state-class warnings targeted by this patch.

## Notes

No Home Assistant service calls or Baxi/Remeha control endpoints were called during validation.