### PR TITLE
[codex] Fix auth cookie handling

### DIFF
--- a/custom_components/remeha_home/__init__.py
+++ b/custom_components/remeha_home/__init__.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import aiohttp
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
 from .api import RemehaHomeOAuth2Implementation, RemehaHomeAPI
 from .config_flow import RemehaHomeLoginFlowHandler
@@ -25,10 +27,12 @@ PLATFORMS: list[Platform] = [
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up Remeha Home."""
     hass.data.setdefault(DOMAIN, {})
+    cookie_jar = aiohttp.CookieJar(quote_cookie=False)
+    session = async_create_clientsession(hass, cookie_jar=cookie_jar)
 
     RemehaHomeLoginFlowHandler.async_register_implementation(
         hass,
-        RemehaHomeOAuth2Implementation(async_get_clientsession(hass)),
+        RemehaHomeOAuth2Implementation(session),
     )
 
     return True


### PR DESCRIPTION
## Summary

- Creates the Remeha Home OAuth client session with an `aiohttp.CookieJar(quote_cookie=False)`.
- Keeps OAuth implementation registration in `async_setup`, so the integration still registers the implementation once for setup, reauth, and existing config-entry flows.
- Avoids reintroducing registration inside `config_flow.py`, which would duplicate the implementation registration.

## Validation

- `.venv\\Scripts\\python.exe -m ruff check .`
- `.venv\\Scripts\\python.exe -m compileall custom_components`
- `git diff --check`

## Relationship to PR #6

This applies the same cookie-quoting idea from PR #6 on top of current `main`, but moves the change to the single registration point in `__init__.py` so existing config entries and reauth paths use the same implementation.